### PR TITLE
setup-java version 수정

### DIFF
--- a/.github/workflows/andriod-build.yml
+++ b/.github/workflows/andriod-build.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
        # 안드로이드 프로젝트 빌드 기본 설정
       - name: Setup JDK 1.8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v1
         with:
           java-version: 1.8
 


### PR DESCRIPTION
## 이슈 번호
- #1
## 주요 변경 사항
- JDK 1.8 버전은 github actions setup-java@1를 사용해 빌드해야 함
- [해당 문서 참고](https://github.com/coturiv/setup-ionic/pull/15)
## 코드 리뷰에서 중점적으로 봐야 할 부분
- github actions test를 위한 코드리뷰 생략
